### PR TITLE
Replace all instances of "googleapis/gnostic" with "google/gnostic" (…

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-*     @googleapis/gnostic
+*     @google/gnostic

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ and later.
 
 1.  Get this package by downloading it with `git clone`.
 
-        git clone https://github.com/googleapis/gnostic
+        git clone https://github.com/google/gnostic
         cd gnostic
 
 2.  Verify that you have a local installation of `protoc`. You can get protoc
@@ -78,7 +78,7 @@ and later.
     which contains a textual representation of the Protocol Buffer description.
     This is mainly for use in testing and debugging.
 
-            gnostic --text-out=petstore.text https://raw.githubusercontent.com/googleapis/gnostic/master/examples/v2.0/json/petstore.json
+            gnostic --text-out=petstore.text https://raw.githubusercontent.com/google/gnostic/master/examples/v2.0/json/petstore.json
 
 7.  For a sample application, see apps/report. This reads a binary Protocol
     Buffer encoding created by **gnostic**.
@@ -91,8 +91,8 @@ and later.
     [plugin.proto](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/compiler/plugin.proto)
     and is described in [plugins/plugin.proto](plugins/plugin.proto). Several
     plugins are implemented in the `plugins` directory. Others, like
-    [gnostic-grpc](https://github.com/googleapis/gnostic-grpc) and
-    [gnostic-go-generator](https://github.com/googleapis/gnostic-go-generator),
+    [gnostic-grpc](https://github.com/google/gnostic-grpc) and
+    [gnostic-go-generator](https://github.com/google/gnostic-go-generator),
     are published in their own repositories. One such plugin is
     [gnostic-vocabulary](plugins/gnostic-vocabulary), which produces a summary
     of the word usage in an APIs interfaces. You can run `gnostic-vocabulary`

--- a/apps/disco/README.md
+++ b/apps/disco/README.md
@@ -6,8 +6,8 @@ descriptions to OpenAPI.
 
 Installation:
 
-        go get github.com/googleapis/gnostic
-        go install github.com/googleapis/gnostic/apps/disco
+        go get github.com/google/gnostic
+        go install github.com/google/gnostic/apps/disco
 
 Usage:
 

--- a/apps/protoc-gen-openapi/README.md
+++ b/apps/protoc-gen-openapi/README.md
@@ -6,8 +6,8 @@ Protocol Buffer service.
 
 Installation:
 
-        go get github.com/googleapis/gnostic
-        go install github.com/googleapis/gnostic/apps/protoc-gen-openapi
+        go get github.com/google/gnostic
+        go install github.com/google/gnostic/apps/protoc-gen-openapi
   
   
 Usage:

--- a/apps/protoc-gen-openapi/examples/google/example/library/v1/openapi.yaml
+++ b/apps/protoc-gen-openapi/examples/google/example/library/v1/openapi.yaml
@@ -1,5 +1,5 @@
 # Generated with protoc-gen-openapi
-# https://github.com/googleapis/gnostic/tree/master/apps/protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/apps/protoc-gen-openapi
 
 openapi: 3.0.3
 info:

--- a/apps/protoc-gen-openapi/examples/tests/bodymapping/openapi.yaml
+++ b/apps/protoc-gen-openapi/examples/tests/bodymapping/openapi.yaml
@@ -1,5 +1,5 @@
 # Generated with protoc-gen-openapi
-# https://github.com/googleapis/gnostic/tree/master/apps/protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/apps/protoc-gen-openapi
 
 openapi: 3.0.3
 info:

--- a/apps/protoc-gen-openapi/examples/tests/mapfields/openapi.yaml
+++ b/apps/protoc-gen-openapi/examples/tests/mapfields/openapi.yaml
@@ -1,5 +1,5 @@
 # Generated with protoc-gen-openapi
-# https://github.com/googleapis/gnostic/tree/master/apps/protoc-gen-openapi
+# https://github.com/google/gnostic/tree/master/apps/protoc-gen-openapi
 
 openapi: 3.0.3
 info:

--- a/apps/protoc-gen-openapi/generator/openapi-v3.go
+++ b/apps/protoc-gen-openapi/generator/openapi-v3.go
@@ -30,7 +30,7 @@ import (
 	v3 "github.com/google/gnostic/openapiv3"
 )
 
-const infoURL = "https://github.com/googleapis/gnostic/tree/master/apps/protoc-gen-openapi"
+const infoURL = "https://github.com/google/gnostic/tree/master/apps/protoc-gen-openapi"
 
 // OpenAPIv3Generator holds internal state needed to generate an OpenAPIv3 document for a transcoded Protocol Buffer service.
 type OpenAPIv3Generator struct {

--- a/gnostic_test.go
+++ b/gnostic_test.go
@@ -111,25 +111,25 @@ func TestSeparateJSON(t *testing.T) {
 
 func TestRemotePetstoreJSON(t *testing.T) {
 	testNormal(t,
-		"https://raw.githubusercontent.com/googleapis/openapi-compiler/master/examples/v2.0/json/petstore.json",
+		"https://raw.githubusercontent.com/google/gnostic/master/examples/v2.0/json/petstore.json",
 		"testdata/v2.0/petstore.text")
 }
 
 func TestRemotePetstoreYAML(t *testing.T) {
 	testNormal(t,
-		"https://raw.githubusercontent.com/googleapis/openapi-compiler/master/examples/v2.0/yaml/petstore.yaml",
+		"https://raw.githubusercontent.com/google/gnostic/master/examples/v2.0/yaml/petstore.yaml",
 		"testdata/v2.0/petstore.text")
 }
 
 func TestRemoteSeparateYAML(t *testing.T) {
 	testNormal(t,
-		"https://raw.githubusercontent.com/googleapis/openapi-compiler/master/examples/v2.0/yaml/petstore-separate/spec/swagger.yaml",
+		"https://raw.githubusercontent.com/google/gnostic/master/examples/v2.0/yaml/petstore-separate/spec/swagger.yaml",
 		"testdata/v2.0/yaml/petstore-separate/spec/swagger.text")
 }
 
 func TestRemoteSeparateJSON(t *testing.T) {
 	testNormal(t,
-		"https://raw.githubusercontent.com/googleapis/openapi-compiler/master/examples/v2.0/json/petstore-separate/spec/swagger.json",
+		"https://raw.githubusercontent.com/google/gnostic/master/examples/v2.0/json/petstore-separate/spec/swagger.json",
 		"testdata/v2.0/yaml/petstore-separate/spec/swagger.text")
 }
 

--- a/linters/node/gnostic-lint-operations/Makefile
+++ b/linters/node/gnostic-lint-operations/Makefile
@@ -1,5 +1,5 @@
 
-GNOSTIC = $(GOPATH)/src/github.com/googleapis/gnostic
+GNOSTIC = $(GOPATH)/src/github.com/google/gnostic
 
 plugin:
 	node_modules/.bin/pbjs -t json \

--- a/linters/node/gnostic-lint-responses/Makefile
+++ b/linters/node/gnostic-lint-responses/Makefile
@@ -1,5 +1,5 @@
 
-GNOSTIC = $(GOPATH)/src/github.com/googleapis/gnostic
+GNOSTIC = $(GOPATH)/src/github.com/google/gnostic
 
 plugin:
 	node_modules/.bin/pbjs -t json \

--- a/linters/node/gnostic-lint-responses/package.json
+++ b/linters/node/gnostic-lint-responses/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Gnostic linter plugin to check responses",
   "main": "gnostic-lint-responses.js",
-  "repository": "git@github.com:googleapis/gnostic.git",
+  "repository": "git@github.com:google/gnostic.git",
   "author": "Mike Kistler",
   "license": "Apache-2.0",
   "dependencies": {

--- a/surface/model_openapiv3.go
+++ b/surface/model_openapiv3.go
@@ -405,7 +405,7 @@ func (b *OpenAPI3Builder) buildFromSchema(name string, schema *openapiv3.Schema)
 
 // buildFromOneOfAnyOfAndAllOf adds appropriate fields to the 'schemaType' given a new 'schemaOrRef'.
 func (b *OpenAPI3Builder) buildFromOneOfAnyOfAndAllOf(schemaOrRef *openapiv3.SchemaOrReference, schemaType *Type) {
-	// Related: https://github.com/googleapis/gnostic-grpc/issues/22
+	// Related: https://github.com/google/gnostic-grpc/issues/22
 	if schema := schemaOrRef.GetSchema(); schema != nil {
 		// Build a temporary type that has the required fields; add the fields to the current schema; remove the
 		// temporary type


### PR DESCRIPTION
…#264)

* Replace all instances of "googleapis/gnostic" with "google/gnostic"

* Rename old references to googleapis/openapi-compiler to google/gnostic