### PR TITLE
Adjust "json-style" naming in protoc-gen-openapi to capitalize schema names

### DIFF
--- a/apps/protoc-gen-openapi/examples/google/example/library/v1/openapi_json.yaml
+++ b/apps/protoc-gen-openapi/examples/google/example/library/v1/openapi_json.yaml
@@ -41,7 +41,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/listShelvesResponse'
+                                $ref: '#/components/schemas/ListShelvesResponse'
         post:
             tags:
                 - LibraryService
@@ -51,7 +51,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/shelf'
+                            $ref: '#/components/schemas/Shelf'
                 required: true
             responses:
                 "200":
@@ -59,7 +59,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/shelf'
+                                $ref: '#/components/schemas/Shelf'
     /v1/shelves/{shelf}:
         get:
             tags:
@@ -79,7 +79,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/shelf'
+                                $ref: '#/components/schemas/Shelf'
         delete:
             tags:
                 - LibraryService
@@ -128,7 +128,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/listBooksResponse'
+                                $ref: '#/components/schemas/ListBooksResponse'
         post:
             tags:
                 - LibraryService
@@ -145,7 +145,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/book'
+                            $ref: '#/components/schemas/Book'
                 required: true
             responses:
                 "200":
@@ -153,7 +153,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/book'
+                                $ref: '#/components/schemas/Book'
     /v1/shelves/{shelf}/books/{book}:
         get:
             tags:
@@ -179,7 +179,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/book'
+                                $ref: '#/components/schemas/Book'
         put:
             tags:
                 - LibraryService
@@ -209,7 +209,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/book'
+                            $ref: '#/components/schemas/Book'
                 required: true
             responses:
                 "200":
@@ -217,7 +217,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/book'
+                                $ref: '#/components/schemas/Book'
         delete:
             tags:
                 - LibraryService
@@ -265,7 +265,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/moveBookRequest'
+                            $ref: '#/components/schemas/MoveBookRequest'
                 required: true
             responses:
                 "200":
@@ -273,7 +273,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/book'
+                                $ref: '#/components/schemas/Book'
     /v1/shelves/{shelf}:merge:
         post:
             tags:
@@ -298,7 +298,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/mergeShelvesRequest'
+                            $ref: '#/components/schemas/MergeShelvesRequest'
                 required: true
             responses:
                 "200":
@@ -306,10 +306,10 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/shelf'
+                                $ref: '#/components/schemas/Shelf'
 components:
     schemas:
-        book:
+        Book:
             properties:
                 name:
                     type: string
@@ -339,29 +339,29 @@ components:
                     description: The last update date and time.
                     format: date-time
             description: A single book in the library.
-        listBooksResponse:
+        ListBooksResponse:
             properties:
                 books:
                     type: array
                     items:
-                        $ref: '#/components/schemas/book'
+                        $ref: '#/components/schemas/Book'
                     description: The list of books.
                 nextPageToken:
                     type: string
                     description: A token to retrieve next page of results. Pass this value in the [ListBooksRequest.page_token][google.example.library.v1.ListBooksRequest.page_token] field in the subsequent call to `ListBooks` method to retrieve the next page of results.
             description: Response message for LibraryService.ListBooks.
-        listShelvesResponse:
+        ListShelvesResponse:
             properties:
                 shelves:
                     type: array
                     items:
-                        $ref: '#/components/schemas/shelf'
+                        $ref: '#/components/schemas/Shelf'
                     description: The list of shelves.
                 nextPageToken:
                     type: string
                     description: A token to retrieve next page of results. Pass this value in the [ListShelvesRequest.page_token][google.example.library.v1.ListShelvesRequest.page_token] field in the subsequent call to `ListShelves` method to retrieve the next page of results.
             description: Response message for LibraryService.ListShelves.
-        mergeShelvesRequest:
+        MergeShelvesRequest:
             properties:
                 name:
                     type: string
@@ -370,7 +370,7 @@ components:
                     type: string
                     description: The name of the shelf we're removing books from and deleting.
             description: Describes the shelf being removed (other_shelf_name) and updated (name) in this merge.
-        moveBookRequest:
+        MoveBookRequest:
             properties:
                 name:
                     type: string
@@ -379,7 +379,7 @@ components:
                     type: string
                     description: The name of the destination shelf.
             description: Describes what book to move (name) and what shelf we're moving it to (other_shelf_name).
-        shelf:
+        Shelf:
             properties:
                 name:
                     type: string

--- a/apps/protoc-gen-openapi/examples/tests/bodymapping/openapi_json.yaml
+++ b/apps/protoc-gen-openapi/examples/tests/bodymapping/openapi_json.yaml
@@ -29,10 +29,10 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/message'
+                                $ref: '#/components/schemas/Message'
 components:
     schemas:
-        message:
+        Message:
             properties:
                 messageId:
                     type: string

--- a/apps/protoc-gen-openapi/examples/tests/jsonoptions/openapi_json.yaml
+++ b/apps/protoc-gen-openapi/examples/tests/jsonoptions/openapi_json.yaml
@@ -34,7 +34,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/message'
+                                $ref: '#/components/schemas/Message'
     /v1/messages/{message_id}:
         patch:
             tags:
@@ -62,10 +62,10 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/message2'
+                                $ref: '#/components/schemas/Message2'
 components:
     schemas:
-        message:
+        Message:
             properties:
                 messageId:
                     type: string
@@ -73,7 +73,7 @@ components:
                     type: string
                 notUsed:
                     type: string
-        message2:
+        Message2:
             properties:
                 message_id:
                     type: string

--- a/apps/protoc-gen-openapi/examples/tests/mapfields/openapi_json.yaml
+++ b/apps/protoc-gen-openapi/examples/tests/mapfields/openapi_json.yaml
@@ -21,7 +21,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/message'
+                            $ref: '#/components/schemas/Message'
                 required: true
             responses:
                 "200":
@@ -29,10 +29,10 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/message'
+                                $ref: '#/components/schemas/Message'
 components:
     schemas:
-        message:
+        Message:
             properties:
                 messageId:
                     type: string

--- a/apps/protoc-gen-openapi/examples/tests/pathparams/openapi_json.yaml
+++ b/apps/protoc-gen-openapi/examples/tests/pathparams/openapi_json.yaml
@@ -27,7 +27,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/message'
+                                $ref: '#/components/schemas/Message'
         post:
             tags:
                 - Messaging
@@ -42,7 +42,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/message'
+                            $ref: '#/components/schemas/Message'
                 required: true
             responses:
                 "200":
@@ -50,7 +50,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/message'
+                                $ref: '#/components/schemas/Message'
     /v1/users/{userId}/messages/{messageId}:
         get:
             tags:
@@ -73,10 +73,10 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/message'
+                                $ref: '#/components/schemas/Message'
 components:
     schemas:
-        message:
+        Message:
             properties:
                 messageId:
                     type: string

--- a/apps/protoc-gen-openapi/examples/tests/protobuftypes/openapi_json.yaml
+++ b/apps/protoc-gen-openapi/examples/tests/protobuftypes/openapi_json.yaml
@@ -35,7 +35,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/message'
+                                $ref: '#/components/schemas/Message'
         post:
             tags:
                 - Messaging
@@ -50,7 +50,7 @@ paths:
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/message'
+                            $ref: '#/components/schemas/Message'
                 required: true
             responses:
                 "200":
@@ -58,7 +58,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/message'
+                                $ref: '#/components/schemas/Message'
         patch:
             tags:
                 - Messaging
@@ -89,7 +89,7 @@ paths:
                     content: {}
 components:
     schemas:
-        message:
+        Message:
             properties:
                 messageId:
                     type: string

--- a/apps/protoc-gen-openapi/generator/openapi-v3.go
+++ b/apps/protoc-gen-openapi/generator/openapi-v3.go
@@ -214,7 +214,7 @@ func (g *OpenAPIv3Generator) formatMessageRef(name string) string {
 	}
 
 	if len(name) > 1 {
-		return strings.ToLower(name[0:1]) + name[1:]
+		return strings.ToUpper(name[0:1]) + name[1:]
 	}
 
 	if len(name) == 1 {
@@ -231,7 +231,7 @@ func (g *OpenAPIv3Generator) formatMessageName(message *protogen.Message) string
 
 	name := string(message.Desc.Name())
 	if len(name) > 0 {
-		return strings.ToLower(name[0:1]) + name[1:]
+		return strings.ToUpper(name[0:1]) + name[1:]
 	}
 
 	return name

--- a/apps/protoc-gen-openapi/plugin_test.go
+++ b/apps/protoc-gen-openapi/plugin_test.go
@@ -26,7 +26,7 @@ var openapiTests = []struct {
 	path      string
 	protofile string
 }{
-	{name: "Google Lbrary example", path: "examples/google/example/library/v1/", protofile: "library.proto"},
+	{name: "Google Library example", path: "examples/google/example/library/v1/", protofile: "library.proto"},
 	{name: "Body mapping", path: "examples/tests/bodymapping/", protofile: "message.proto"},
 	{name: "Map fields", path: "examples/tests/mapfields/", protofile: "message.proto"},
 	{name: "Path params", path: "examples/tests/pathparams/", protofile: "message.proto"},


### PR DESCRIPTION
This aligns protoc-gen-openapi output with tthe Google API Discovery Document convention of capitalizing schema names. This capitalization is also in OpenAPI descriptions translated from Discovery Docs, for example:

https://github.com/APIs-guru/openapi-directory/blob/16231c13a2041427a3f799a4d8053cb6cb9be4a8/APIs/googleapis.com/translate/v3/openapi.yaml#L742

(a very minor typo is also fixed in this commit)