### PR TITLE
Add support for nested protobuf message definitions (protoc-gen-openapi)

### DIFF
--- a/apps/protoc-gen-openapi/examples/tests/mapfields/message.proto
+++ b/apps/protoc-gen-openapi/examples/tests/mapfields/message.proto
@@ -31,12 +31,11 @@ service Messaging {
     }
 }
 
-message SubMessage {
-    int64 id = 1;
-    string label = 2;
-}
-
 message Message {
+    message SubMessage {
+        int64 id = 1;
+        string label = 2;
+    }
     string message_id = 1;
     SubMessage sub_message = 2;
     repeated string string_list = 3;

--- a/apps/protoc-gen-openapi/generator/openapi-v3.go
+++ b/apps/protoc-gen-openapi/generator/openapi-v3.go
@@ -116,7 +116,7 @@ func (g *OpenAPIv3Generator) buildDocumentV3() *v3.Document {
 	for len(g.requiredSchemas) > 0 {
 		count := len(g.requiredSchemas)
 		for _, file := range g.plugin.Files {
-			g.addSchemasToDocumentV3(d, file)
+			g.addSchemasToDocumentV3(d, file.Messages)
 		}
 		g.requiredSchemas = g.requiredSchemas[count:len(g.requiredSchemas)]
 	}
@@ -676,9 +676,14 @@ func (g *OpenAPIv3Generator) schemaOrReferenceForField(field protoreflect.FieldD
 }
 
 // addSchemasToDocumentV3 adds info from one file descriptor.
-func (g *OpenAPIv3Generator) addSchemasToDocumentV3(d *v3.Document, file *protogen.File) {
+func (g *OpenAPIv3Generator) addSchemasToDocumentV3(d *v3.Document, messages []*protogen.Message) {
 	// For each message, generate a definition.
-	for _, message := range file.Messages {
+	for _, message := range messages {
+		// Add any messages that are defined inside this message.
+		if message.Messages != nil {
+			g.addSchemasToDocumentV3(d, message.Messages)
+		}
+
 		typeName := fullMessageTypeName(message.Desc)
 
 		// Only generate this if we need it and haven't already generated it.


### PR DESCRIPTION
This extends protoc-gen-openapi to support message definitions that are nested inside other message definitions.

With this change, generated schema names are the "local" message names only. We may want to improve this by making the generated names hierarchical, i.e. "Message_SubMessage" for the test example.

Anecdotally, I noticed that the Discovery document for the Google Translate API v3 contains "local" names for nested messages. Specifically, the [`Glossary`](https://github.com/googleapis/googleapis/blob/02df998e40733c077aa0fc3f35a6b2d48aa8bf84/google/cloud/translate/v3/translation_service.proto#L970) message contains [`LanguageCodePair`](https://github.com/googleapis/googleapis/blob/02df998e40733c077aa0fc3f35a6b2d48aa8bf84/google/cloud/translate/v3/translation_service.proto#L977) and [`LanguageCodesSet`](https://github.com/googleapis/googleapis/blob/02df998e40733c077aa0fc3f35a6b2d48aa8bf84/google/cloud/translate/v3/translation_service.proto#L988) nested messages, but these are named `LanguageCodesSet` and `LanguagePair` in the [Discovery document](https://translation.googleapis.com/$discovery/rest?version=v3) instead of `Glossary_LanguageCodesSet` and `Glossary_LanguagePair`, which I would have expected.